### PR TITLE
Introducing "no auth" + better Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
       "homepage": "https://rohmann.us"
     }
   ],
-  "type": "wordpress-muplugin",
+  "type": "wordpress-plugin",
   "require": {
     "php": ">=5.3.0",
     "composer/installers": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,19 @@
 {
-  "name": "rohmann/global-smtp",
+  "name": "enricodeleo/global-smtp",
   "description": "Utility plugin to setup SMTP mail via constants in wp-config.php",
   "keywords": ["wordpress", "smtp", "multisite"],
-  "homepage": "https://github.com/rohmann/global-smtp",
+  "homepage": "https://github.com/enricodeleo/global-smtp",
   "license": "GPLv2",
   "authors": [
     {
       "name": "Alexander Rohmann",
       "email": "alexander@rohmann.us",
       "homepage": "https://rohmann.us"
+    },
+    {
+      "name": "Enrico Deleo",
+      "email": "hello@enricodeleo.com",
+      "homepage": "https://enricodeleo.com"
     }
   ],
   "type": "wordpress-plugin",

--- a/global-smtp.php
+++ b/global-smtp.php
@@ -269,7 +269,12 @@ class Global_SMTP_Mailer {
 
 		//assumed
 		$phpmailer->Port = (int) GLOBAL_SMTP_PORT;
-		$phpmailer->SMTPSecure = GLOBAL_SMTP_SECURE;
+		if ( GLOBAL_SMTP_SECURE == 'none' ) {
+      $phpmailer->SMTPSecure = '';
+    }
+    else {
+      $phpmailer->SMTPSecure = GLOBAL_SMTP_SECURE;
+    }
 		$phpmailer->AuthType = GLOBAL_SMTP_AUTH_TYPE;
 
 		//Optional


### PR DESCRIPTION
If you're using tools like mailcatcher (or any fake smtp tool) you need to use unauthenticated smtp. With #master it didn't worked (maybe a space was automatically append to the global var, dunno) so I introduced a simple if that did the job.

Furthermore, I changed composer.json since I found more useful a non must-use plugin in case someone uses, for example, ssmtp in production and doesn't need this plugin to be active.
